### PR TITLE
Update Gnome SDK to version 43 and Update Shared Modules

### DIFF
--- a/com.github.afrantzis.Bless.yaml
+++ b/com.github.afrantzis.Bless.yaml
@@ -2,7 +2,7 @@
 app-id: com.github.afrantzis.Bless
 runtime: org.gnome.Platform
 sdk: org.gnome.Sdk
-runtime-version: '42'
+runtime-version: '43'
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.mono6
 rename-desktop-file: bless.desktop


### PR DESCRIPTION
I realize you have just updated the SDK to version 42. However, version 43 is available and works perfectly in my testing.
Updating the SDK here will also update the freedesktop platform to version 22.08 which was released recently keeping things up to date.

I have also updated the Shared Modules