### PR TITLE
Patching gtk-sharp to build with more aggressive compiler flags

### DIFF
--- a/com.github.afrantzis.Bless.yaml
+++ b/com.github.afrantzis.Bless.yaml
@@ -35,6 +35,8 @@ modules:
         commit: 3440993e00c89791c5401ae0dcc7508d81347739
       - type: patch
         path: gtk-sharp2-2.12.12-glib-include.patch
+      - type: patch
+        path: window.patch
       - type: shell
         commands:
           - ./bootstrap-2.12 --prefix=/usr

--- a/window.patch
+++ b/window.patch
@@ -1,0 +1,13 @@
+diff --git a/gdk/glue/windowmanager.c b/gdk/glue/windowmanager.c
+index 484d713b7..854d84031 100644
+--- a/gdk/glue/windowmanager.c
++++ b/gdk/glue/windowmanager.c
+@@ -110,7 +110,7 @@ gtksharp_get_gdk_net_client_list (int *count)
+ 	list = g_malloc (*count * sizeof (gpointer));
+ 	/* Put all of the windows into a GList to return */
+ 	for (i = 0; i < *count; i ++) {
+-		list [i] = data [i];
++		list [i] = (gpointer*) data [i];
+ 		g_message ("WinID: %d", list [i]);
+ 	}
+ 


### PR DESCRIPTION
windowmanager.c: In function ‘gtksharp_get_gdk_net_client_list’: windowmanager.c:113:26: error: assignment to ‘gpointer’ {aka ‘void *’} from ‘long int’ makes pointer from integer without a cast [-Wint-conversion]
  113 |                 list [i] = data [i];
      |                          ^
In file included from /usr/include/glib-2.0/glib.h:64,
                 from /app/include/gtk-2.0/gdk/gdktypes.h:36,
                 from /app/include/gtk-2.0/gdk/gdkscreen.h:32,
                 from windowmanager.c:27: